### PR TITLE
Temp dir

### DIFF
--- a/src/blender/install.rs
+++ b/src/blender/install.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 ///
 /// This gives you access to `bpy.ops.import_export.mesh2json()` from Blender
 pub fn install_mesh_to_json() -> std::io::Result<()> {
-    // Write our addon to a tmp file. Our INSTALL_MESH_TO_JSON will look for this tmp file
+    // Write our addon to a tmp file. Our `install_mesh_to_json_script` will look for this tmp file
     // when installing the addon.
     let addon_file_path = temp_dir().join("blender-mesh-to-json.py");
     let mesh_to_json_addon = include_str!("../../blender-mesh-to-json.py");
@@ -48,7 +48,7 @@ bpy.ops.wm.save_userpref()
 ///
 /// This gives you access to `bpy.ops.import_export.armature2json()` from Blender
 pub fn install_armature_to_json() -> std::io::Result<()> {
-    // Write our addon to a tmp file. Our INSTALL_MESH_TO_JSON will look for this tmp file
+    // Write our addon to a tmp file. Our `install_armature_to_json_script` will look for this tmp file
     // when installing the addon.
     let addon_file_path = temp_dir().join("blender-armature-to-json.py");
     let armature_to_json = include_str!("../../blender-armature-to-json.py");

--- a/src/blender/install.rs
+++ b/src/blender/install.rs
@@ -1,3 +1,4 @@
+use std::env::temp_dir;
 use std::fs::File;
 use std::io::Write;
 use std::process::Command;
@@ -8,15 +9,33 @@ use std::process::Command;
 pub fn install_mesh_to_json() -> std::io::Result<()> {
     // Write our addon to a tmp file. Our INSTALL_MESH_TO_JSON will look for this tmp file
     // when installing the addon.
+    let addon_file_path = temp_dir().join("blender-mesh-to-json.py");
     let mesh_to_json_addon = include_str!("../../blender-mesh-to-json.py");
-    let mut addon_file = File::create("/tmp/blender-mesh-to-json.py")?;
+    let mut addon_file = File::create(&addon_file_path)?;
     addon_file.write_all(mesh_to_json_addon.as_bytes()).unwrap();
+
+    let install_mesh_to_json_script = format!(r#"
+# Install the addon and save the user's preferences
+import bpy
+import os
+
+# Get the absolute path to the addon
+dir = os.path.dirname(__file__)
+addonFilePath = '{}'
+
+# Install the addon, enable it and save the user's preferences so that it
+# is available whenever Blender is opened in the future
+bpy.ops.preferences.addon_install(filepath=addonFilePath)
+bpy.ops.preferences.addon_enable(module='blender-mesh-to-json')
+bpy.ops.wm.save_userpref()
+    "#,
+    addon_file_path.display());
 
     // TODO: Support an environment variable to override the path to the executable
     let blender_executable = "blender";
     Command::new(blender_executable)
         .arg("--background")
-        .args(&["--python-expr", INSTALL_MESH_TO_JSON])
+        .args(&["--python-expr", &install_mesh_to_json_script])
         .spawn()
         .unwrap()
         .wait()
@@ -31,15 +50,29 @@ pub fn install_mesh_to_json() -> std::io::Result<()> {
 pub fn install_armature_to_json() -> std::io::Result<()> {
     // Write our addon to a tmp file. Our INSTALL_MESH_TO_JSON will look for this tmp file
     // when installing the addon.
+    let addon_file_path = temp_dir().join("blender-armature-to-json.py");
     let armature_to_json = include_str!("../../blender-armature-to-json.py");
-    let mut addon_file = File::create("/tmp/blender-armature-to-json.py")?;
+    let mut addon_file = File::create(&addon_file_path)?;
     addon_file.write_all(armature_to_json.as_bytes()).unwrap();
+
+    let install_armature_to_json_script = format!(r#"
+import bpy
+
+addonFilePath = '{}'
+
+# Install the addon, enable it and save the user's preferences so that it
+# is available whenever Blender is opened in the future
+bpy.ops.preferences.addon_install(filepath=addonFilePath)
+bpy.ops.preferences.addon_enable(module='blender-armature-to-json')
+bpy.ops.wm.save_userpref()
+    "#,
+    addon_file_path.display());
 
     // TODO: Support an environment variable to override the path to the executable
     let blender_executable = "blender";
     Command::new(blender_executable)
         .arg("--background")
-        .args(&["--python-expr", INSTALL_ARMATURE_TO_JSON])
+        .args(&["--python-expr", &install_armature_to_json_script])
         .spawn()
         .unwrap()
         .wait()
@@ -47,31 +80,3 @@ pub fn install_armature_to_json() -> std::io::Result<()> {
 
     Ok(())
 }
-
-static INSTALL_MESH_TO_JSON: &'static str = r#"
-# Install the addon and save the user's preferences
-import bpy
-import os
-
-# Get the absolute path to the addon
-dir = os.path.dirname(__file__)
-addonFilePath = '/tmp/blender-mesh-to-json.py'
-
-# Install the addon, enable it and save the user's preferences so that it
-# is available whenever Blender is opened in the future
-bpy.ops.preferences.addon_install(filepath=addonFilePath)
-bpy.ops.preferences.addon_enable(module='blender-mesh-to-json')
-bpy.ops.wm.save_userpref()
-"#;
-
-static INSTALL_ARMATURE_TO_JSON: &'static str = r#"
-import bpy
-
-addonFilePath = '/tmp/blender-armature-to-json.py'
-
-# Install the addon, enable it and save the user's preferences so that it
-# is available whenever Blender is opened in the future
-bpy.ops.preferences.addon_install(filepath=addonFilePath)
-bpy.ops.preferences.addon_enable(module='blender-armature-to-json')
-bpy.ops.wm.save_userpref()
-"#;


### PR DESCRIPTION
Changes the installation scripts to use the location at [`std::env::temp_dir`](https://doc.rust-lang.org/std/env/fn.temp_dir.html) instead of the hard-coded `/tmp` directory.