### PR TITLE
Unicode path fix in python install script

### DIFF
--- a/src/blender/install.rs
+++ b/src/blender/install.rs
@@ -22,7 +22,7 @@ import os
 
 # Get the absolute path to the addon
 dir = os.path.dirname(__file__)
-addonFilePath = '{}'
+addonFilePath = r'{}'
 
 # Install the addon, enable it and save the user's preferences so that it
 # is available whenever Blender is opened in the future
@@ -61,7 +61,7 @@ pub fn install_armature_to_json() -> std::io::Result<()> {
         r#"
 import bpy
 
-addonFilePath = '{}'
+addonFilePath = r'{}'
 
 # Install the addon, enable it and save the user's preferences so that it
 # is available whenever Blender is opened in the future


### PR DESCRIPTION
Made the blender install scripts use r"" python strings. This prevents unicode errors on windows, where paths can be things like `C:\User...`. r"" turns the string into `C:\\User\\...` which escapes the unicode sequence.

Error that would appear when running `landon.exe blender install mesh-to-json` looks like:
```
Blender 2.80 (sub 75) (hash f6cb5f54494e built 2019-07-29 09:44 AM)
Read prefs: C:\Users\...\AppData\Roaming\Blender Foundation\Blender\2.80\config\userpref.blend
found bundled python: C:\Program Files\Blender Foundation\Blender\2.80\python
Error:   File "<string>", line 8
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape

location: <unknown location>:-1

  File "<string>", line 8
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape

location: <unknown location>:-1

location: <unknown location>:-1

Blender quit
```
After the fix, output is:
```
Blender 2.80 (sub 75) (hash f6cb5f54494e built 2019-07-29 09:44 AM)
Read prefs: C:\Users\...\AppData\Roaming\Blender Foundation\Blender\2.80\config\userpref.blend
found bundled python: C:\Program Files\Blender Foundation\Blender\2.80\python
Info: Modules Installed () from 'C:\\Users\\...\\AppData\\Local\\Temp\\blender-mesh-to-json.py' into 'C:\\Users\\...\\AppData\\Roaming\\Blender Foundation\\Blender\\2.80\\scripts\\addons'
Writing userprefs: 'C:\Users\...\AppData\Roaming\Blender Foundation\Blender\2.80\config\userpref.blend' ok
reloading addon: blender-mesh-to-json 1589188990.048061 1589189581.6098843 'C:\\Users\\...\\AppData\\Roaming\\Blender Foundation\\Blender\\2.80\\scripts\\addons\\blender-mesh-to-json.py'
Modules Installed () from 'C:\\Users\\...\\AppData\\Local\\Temp\\blender-mesh-to-json.py' into 'C:\\Users\\...\\AppData\\Roaming\\Blender Foundation\\Blender\\2.80\\scripts\\addons'
Info: Modules Installed () from 'C:\\Users\\...\\AppData\\Local\\Temp\\blender-mesh-to-json.py' into 'C:\\Users\\...\\AppData\\Roaming\\Blender Foundation\\Blender\\2.80\\scripts\\addons'
module changed on disk: 'C:\\Users\\...\\AppData\\Roaming\\Blender Foundation\\Blender\\2.80\\scripts\\addons\\blender-mesh-to-json.py' reloading...

Blender quit
```