### PR TITLE
Simplify single indexed vertices

### DIFF
--- a/blender-mesh/src/bone.rs
+++ b/blender-mesh/src/bone.rs
@@ -1,4 +1,4 @@
-use crate::vertex_attributes::{BoneInfluences, MultiIndexedVertexAttributes};
+use crate::vertex_attributes::{VertexBoneInfluences, MultiIndexedVertexAttributes};
 
 /// The number of bones that influence each uniform.
 ///
@@ -55,7 +55,7 @@ impl MultiIndexedVertexAttributes {
         }
 
         {
-            let BoneInfluences {
+            let VertexBoneInfluences {
                 bones_per_vertex,
                 bone_indices,
                 bone_weights,

--- a/blender-mesh/src/lib.rs
+++ b/blender-mesh/src/lib.rs
@@ -26,7 +26,9 @@ pub use self::export::*;
 pub use crate::bounding_box::BoundingBox;
 use crate::custom_property::CustomProperty;
 pub use crate::material::PrincipledBSDF;
-pub use crate::vertex_attributes::{MultiIndexedVertexAttributes, SingleIndexedVertexAttributes};
+pub use crate::vertex_attributes::{
+    BoneInfluence, MultiIndexedVertexAttributes, SingleIndexedVertexAttributes, Vertex,
+};
 pub use material::{Channel, MaterialInput};
 use std::collections::HashMap;
 

--- a/blender-mesh/src/vertex_attributes/mod.rs
+++ b/blender-mesh/src/vertex_attributes/mod.rs
@@ -97,7 +97,7 @@ pub struct MultiIndexedVertexAttributes {
     pub(crate) positions: IndexedAttribute,
     pub(crate) normals: Option<IndexedAttribute>,
     pub(crate) uvs: Option<IndexedAttribute>,
-    pub(crate) bone_influences: Option<BoneInfluences>,
+    pub(crate) bone_influences: Option<VertexBoneInfluences>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
@@ -144,7 +144,7 @@ impl From<SingleIndexedVertexAttributes> for VertexAttributes {
 /// TODO: Remove this and use VertexAttribute with something like attribute_size: Varies(vec![])
 /// this allows us to handle all attributes the same way.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default)]
-pub struct BoneInfluences {
+pub struct VertexBoneInfluences {
     /// The number of bones that affect each vertex.
     ///
     /// Example: [3, 5, 2] would mean that the first vertex is influenced by 3 bones, second by


### PR DESCRIPTION
Modern graphics APIs such as Metal/Vulkan/etc make it easy to buffer data onto the GPU in a structured manner (you're just copying bytes to buffers).

To align with that, we are returning a Vec<Vertex> and letting the caller
decide how to buffer the data.

Previously we returned separate Vec's of data since when first starting with WebGL/OpenGL it can be easier to just dump things into a bunch of buffers than to interleave.

Instead of encouraging worse practices we should expose functions and documentation to make it easier to do things properly.

---

There's still a lot of refactoring of all of these crates that need to happen. Lots of code that I wrote when I was first learning Rust... It's unpleasant to work with right now.