### PR TITLE
Added material indices.

### DIFF
--- a/blender-mesh-to-json.py
+++ b/blender-mesh-to-json.py
@@ -46,10 +46,11 @@ class MeshToJSON(bpy.types.Operator):
             'bounding_box': {
                 'min_corner': [], 'max_corner': []
             },
-            'materials': {},
+            'materials': [],
             'custom_properties': {},
             'attribs': {
                 'vertices_in_each_face': [],
+                'material_index': [],
                 'positions': {
                     'indices': [],
                     'attribute': {
@@ -101,6 +102,7 @@ class MeshToJSON(bpy.types.Operator):
         for face in mesh.data.polygons:
             num_vertices_in_face = len(face.vertices)
             mesh_json['attribs']['vertices_in_each_face'].append(num_vertices_in_face)
+            mesh_json['attribs']['material_index'].append(face.material_index)
 
             for i in range(num_vertices_in_face):
                 mesh_json['attribs']['positions']['indices'].append(face.vertices[i])
@@ -288,12 +290,13 @@ class MeshToJSON(bpy.types.Operator):
                             normalMapNode = link.from_node
                             normalMap = normalMapNode.inputs['Color'].links[0].from_node.image.name
 
-                    mesh_json['materials'][material.name] = {
+                    mesh_json['materials'].append({
+                        'name': material.name,
                         'base_color': baseColor,
                         'roughness': roughness,
                         'metallic': metallic,
                         'normal_map': normalMap
-                    }
+                    })
 
         for property in mesh.keys():
             # Not sure what this is but it gets automatically added into the properties. So we ignore it

--- a/blender-mesh-to-json.py
+++ b/blender-mesh-to-json.py
@@ -112,14 +112,11 @@ class MeshToJSON(bpy.types.Operator):
                 # Especially important for smoothed models that mostly re-use
                 # the same normals. Test this by making a cube with to faces
                 # that have the same normal
-                mesh_json['attribs']['normals']['indices'].append(index)
+                mesh_json['attribs']['normals']['indices'].append(face.vertices[i])
                 if mesh.data.uv_layers:
                     mesh_json['attribs']['uvs']['indices'].append(face.loop_indices[i])
 
             # TODO: Don't append normals if we've already encountered them
-            mesh_json['attribs']['normals']['attribute']['data'].append(face.normal.x)
-            mesh_json['attribs']['normals']['attribute']['data'].append(face.normal.y)
-            mesh_json['attribs']['normals']['attribute']['data'].append(face.normal.z)
 
             index += 1
 
@@ -127,6 +124,10 @@ class MeshToJSON(bpy.types.Operator):
             mesh_json['attribs']['positions']['attribute']['data'].append(vert.co.x)
             mesh_json['attribs']['positions']['attribute']['data'].append(vert.co.y)
             mesh_json['attribs']['positions']['attribute']['data'].append(vert.co.z)
+
+            mesh_json['attribs']['normals']['attribute']['data'].append(vert.normal.x)
+            mesh_json['attribs']['normals']['attribute']['data'].append(vert.normal.y)
+            mesh_json['attribs']['normals']['attribute']['data'].append(vert.normal.z)
 
             num_groups = len(list(vert.groups))
             for group in vert.groups:

--- a/blender-mesh/src/create_mesh/pbr_cube_without_textures.rs
+++ b/blender-mesh/src/create_mesh/pbr_cube_without_textures.rs
@@ -4,25 +4,26 @@ use crate::{
     VertexAttribute,
 };
 use std::collections::HashMap;
+use crate::CustomProperty::Vec;
 
 impl BlenderMesh {
     /// Create a default Blender cube with uniform PBR texture inputs.
     ///
     /// A 2x2x2 cube centered about the origin.
     pub fn pbr_cube_without_textures() -> Self {
-        let mut materials = HashMap::with_capacity(1);
-        materials.insert(
-            "Default".to_string(),
+        let materials = vec![
             PrincipledBSDF {
+                name: String::from("Default"),
                 base_color: MaterialInput::Uniform([0.4, 0.5, 0.6]),
                 roughness: MaterialInput::Uniform(0.2),
                 metallic: MaterialInput::Uniform(0.3),
                 normal_map: None,
             },
-        );
+        ];
 
         let multi_indexed_vertex_attributes = MultiIndexedVertexAttributes {
             vertices_in_each_face: vec![4, 4, 4, 4, 4, 4],
+            material_index: vec![0,0,0,0,0,0],
             positions: IndexedAttribute::new(
                 vec![
                     0, 1, 2, 3, 4, 7, 6, 5, 0, 4, 5, 1, 1, 5, 6, 2, 2, 6, 7, 3, 4, 0, 3, 7,

--- a/blender-mesh/src/lib.rs
+++ b/blender-mesh/src/lib.rs
@@ -75,8 +75,7 @@ pub struct BlenderMesh {
     bounding_box: BoundingBox,
     #[serde(alias = "attribs")]
     multi_indexed_vertex_attributes: MultiIndexedVertexAttributes,
-    #[serde(default, serialize_with = "serialize_hashmap_deterministic")]
-    materials: HashMap<String, PrincipledBSDF>,
+    materials: Vec<PrincipledBSDF>,
     #[serde(default, serialize_with = "serialize_hashmap_deterministic")]
     custom_properties: HashMap<String, CustomProperty>,
 }
@@ -93,12 +92,20 @@ impl BlenderMesh {
     }
 
     /// A map of material name to the material's data
-    pub fn materials(&self) -> &HashMap<String, PrincipledBSDF> {
+    pub fn materials(&self) -> HashMap<String, PrincipledBSDF> {
+        let mut res = HashMap::new();
+        for material in &self.materials {
+            res.insert(material.name.clone(), material.clone());
+        }
+        res
+    }
+
+    pub fn materials_vec(&self) -> &Vec<PrincipledBSDF> {
         &self.materials
     }
 
     /// A mutable map of material name to the material's data
-    pub fn materials_mut(&mut self) -> &mut HashMap<String, PrincipledBSDF> {
+    pub fn materials_mut(&mut self) -> &mut Vec<PrincipledBSDF> {
         &mut self.materials
     }
 

--- a/blender-mesh/src/material.rs
+++ b/blender-mesh/src/material.rs
@@ -8,6 +8,8 @@
 /// https://docs.blender.org/manual/en/latest/render/cycles/nodes/types/shaders/principled.html
 #[derive(Debug, Serialize, Deserialize, PartialEq, Default, Clone)]
 pub struct PrincipledBSDF {
+    /// Material name
+    pub(crate) name: String,
     /// [r, g, b]
     pub(crate) base_color: MaterialInput<[f32; 3], String>,
     /// roughness
@@ -76,12 +78,14 @@ where
 impl PrincipledBSDF {
     /// Create a new physically-based material.
     pub fn new(
+        name: String,
         base_color: MaterialInput<[f32; 3], String>,
         roughness: MaterialInput<f32, (String, Channel)>,
         metallic: MaterialInput<f32, (String, Channel)>,
         normal_map: Option<String>,
     ) -> Self {
         PrincipledBSDF {
+            name,
             base_color,
             roughness,
             metallic,

--- a/blender-mesh/src/vertex_attributes/mod.rs
+++ b/blender-mesh/src/vertex_attributes/mod.rs
@@ -94,6 +94,7 @@ pub struct MultiIndexedVertexAttributes {
     // - Calculating vertex tangents, where all vertices in the same face will have the same
     //   tangent.
     pub(crate) vertices_in_each_face: Vec<u8>,
+    pub(crate) material_index: Vec<u16>,
     pub(crate) positions: IndexedAttribute,
     pub(crate) normals: Option<IndexedAttribute>,
     pub(crate) uvs: Option<IndexedAttribute>,

--- a/blender-mesh/src/vertex_attributes/single_indexed.rs
+++ b/blender-mesh/src/vertex_attributes/single_indexed.rs
@@ -25,6 +25,7 @@ pub struct SingleIndexedVertexAttributes {
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Default)]
 pub struct Vertex {
     pub(crate) position: [f32; 3],
+    pub(crate) material_index: u16,
     pub(crate) normal: Option<[f32; 3]>,
     pub(crate) face_tangent: Option<[f32; 3]>,
     pub(crate) uv: Option<[f32; 2]>,
@@ -51,6 +52,9 @@ impl Vertex {
     pub fn uv(&self) -> Option<[f32; 2]> {
         self.uv
     }
+
+    /// The index of material associated with face
+    pub fn material_index(&self) -> u16 { self.material_index }
 
     /// The bones that influence this Vertex.
     ///


### PR DESCRIPTION
There were no material indices attachments, I've added some.
Alas! There is no backward compatibility. The reason is that initially it was considered that blender mesh has a map which maps attached materials names to instances. But that's wrong! Materials attachment is indexed array rather than a map.